### PR TITLE
Working "open in" functionality

### DIFF
--- a/Replete/AppDelegate.m
+++ b/Replete/AppDelegate.m
@@ -175,16 +175,25 @@
     if (url != nil && [url isFileURL]) {
 
         NSLog(@"Accepting file URL for evaluation: %@", [url absoluteString]);
+        NSError *err;
         NSString *urlContent = [NSString stringWithContentsOfURL:url
                                                     usedEncoding: NULL
-                                                           error: NULL];
+                                                           error: &err];
         if (urlContent != nil) {
 
             NSString *urlContentWrappedInDo = [NSString stringWithFormat: @"(do %@)",
                                                urlContent];
-
             NSLog(@"Evaluating code: %@", urlContentWrappedInDo);
             [self evaluate: urlContentWrappedInDo];
+
+        } else {
+
+            UIAlertView *alertView = [[UIAlertView alloc] initWithTitle:@"Error accepting file"
+                                                                message:[err localizedDescription]
+                                                               delegate:self
+                                                      cancelButtonTitle:@"Cancel"
+                                                      otherButtonTitles:nil];
+            [alertView show];
 
         }
     }

--- a/Replete/AppDelegate.m
+++ b/Replete/AppDelegate.m
@@ -190,7 +190,7 @@
                                                            error: &err];
         if (urlContent != nil) {
 
-            NSString *urlContentWrappedInDo = [NSString stringWithFormat: @"(do %@)",
+            NSString *urlContentWrappedInDo = [NSString stringWithFormat: @"(do %@\n)",
                                                urlContent];
             
             if ([self initialized]) {

--- a/Replete/AppDelegate.m
+++ b/Replete/AppDelegate.m
@@ -15,6 +15,8 @@
 @property (strong, nonatomic) JSValue* readEvalPrintFn;
 @property (strong, nonatomic) JSValue* isReadableFn;
 @property (nonatomic, copy) void (^myPrintCallback)(NSString*);
+@property BOOL initialized;
+@property NSString *codeToBeEvaluatedWhenReady;
 
 @end
 
@@ -105,6 +107,13 @@
     //JSValue* response = [readEvalPrintFn callWithArguments:@[@"(def a 3)"]];
     //NSLog(@"%@", [response toString]);
 
+    self.initialized = true;
+
+    if ([self codeToBeEvaluatedWhenReady]) {
+        NSLog(@"Delayed code to be evaluated: %@", [self codeToBeEvaluatedWhenReady]);
+        [self evaluate: [self codeToBeEvaluatedWhenReady]];
+    }
+
 }
 
 - (void)processFile:(NSString*)path calling:(NSString*)fn inContext:(JSContext*)context
@@ -183,8 +192,14 @@
 
             NSString *urlContentWrappedInDo = [NSString stringWithFormat: @"(do %@)",
                                                urlContent];
-            NSLog(@"Evaluating code: %@", urlContentWrappedInDo);
-            [self evaluate: urlContentWrappedInDo];
+            
+            if ([self initialized]) {
+                NSLog(@"Evaluating code: %@", urlContentWrappedInDo);
+                [self evaluate: urlContentWrappedInDo];
+            } else {
+                NSLog(@"Code to be evaluated when ready: %@", urlContentWrappedInDo);
+                self.codeToBeEvaluatedWhenReady = urlContentWrappedInDo;
+            }
 
         } else {
 

--- a/Replete/AppDelegate.m
+++ b/Replete/AppDelegate.m
@@ -173,7 +173,20 @@
         annotation:(id)annotation
 {
     if (url != nil && [url isFileURL]) {
-        NSLog(@"%@", [url absoluteString]);
+
+        NSLog(@"Accepting file URL for evaluation: %@", [url absoluteString]);
+        NSString *urlContent = [NSString stringWithContentsOfURL:url
+                                                    usedEncoding: NULL
+                                                           error: NULL];
+        if (urlContent != nil) {
+
+            NSString *urlContentWrappedInDo = [NSString stringWithFormat: @"(do %@)",
+                                               urlContent];
+
+            NSLog(@"Evaluating code: %@", urlContentWrappedInDo);
+            [self evaluate: urlContentWrappedInDo];
+
+        }
     }
     return YES;
 }


### PR DESCRIPTION
"Open in" from other apps now seems to be working.

I have tested with Dropbox and Lisping.

I do not yet ask for confirmation from the user before loading.

Handling "open in" when the app is not already running is tricky, since we have to wait for the JavaScript things to be initialized. There is probably a better way of handling this than what I'm doing now. (For some reason the eval output is not shown in this case.)

So a few remaining things to work out, but it should be usable.

![screenshot](https://cloud.githubusercontent.com/assets/1647562/8505519/8ab393b0-21e8-11e5-8e06-eb381542d637.jpg)
