### PR TITLE
replete:// URL scheme added to the app

### DIFF
--- a/Replete/AppDelegate.m
+++ b/Replete/AppDelegate.m
@@ -216,6 +216,8 @@
  sourceApplication:(NSString *)sourceApplication
         annotation:(id)annotation
 {
+    NSLog(@"this is passed in: %@", [url absoluteString]);
+
     if (url != nil && [url isFileURL]) {
 
         NSLog(@"Accepting file URL for evaluation: %@", [url absoluteString]);

--- a/Replete/Info.plist
+++ b/Replete/Info.plist
@@ -35,6 +35,19 @@
 	<string>1.6</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>com.fikesfarm.Replete</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>replete</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleVersion</key>
 	<string>37</string>
 	<key>LSRequiresIPhoneOS</key>


### PR DESCRIPTION
Added the URL scheme to the app **replete://** so that the app can be invoked from other apps.

To test this:

* build the app
* run it in the simulator
* close Replete in the simulator
* open Safari
* in the URL bar type in **replete://this/is/awesome**

# Why?

With great iOS apps like [Workflow](https://workflow.is/) you can create your own workflows, read "custom scripts", which call out to various other apps which support URL schemes.

One notable app that can be used this way is [Pythonista](http://omz-software.com/pythonista/) which allows you create your own Python scripts.

Well, I think it would be great for Replete to be able to do the same, only with ClojureScript:

* User invokes it like **replete://script/arg1/arg2**
* The script **script** runs taking in **arg1** & **arg2** as arguments returning the results

(Note: the above is just an example, the argument passing and script invocation can be done in any other fashion, REST-ful or not...)

My change just adds the ability for the arguments to be passed in to Replete. But before I try to attempt to add the rest of the functionality, I'd like to ask, is this something that would be interesting to have?

Thanks 