### PR TITLE
Handle only ClojureScript source files

### DIFF
--- a/Replete/Info.plist
+++ b/Replete/Info.plist
@@ -79,7 +79,7 @@
 			<key>UTTypeDescription</key>
 			<string>ClojureScript Source Code</string>
 			<key>UTTypeIdentifier</key>
-			<string>org.clojure.cljs</string>
+			<string>org.clojurescript</string>
 			<key>UTTypeTagSpecification</key>
 			<dict>
 				<key>public.source-code</key>
@@ -97,7 +97,7 @@
 			<key>UTTypeDescription</key>
 			<string>ClojureScript Source Code</string>
 			<key>UTTypeIdentifier</key>
-			<string>org.clojure.cljs</string>
+			<string>org.clojurescript</string>
 			<key>UTTypeTagSpecification</key>
 			<dict>
 				<key>public.source-code</key>

--- a/Replete/Info.plist
+++ b/Replete/Info.plist
@@ -10,14 +10,14 @@
 			<key>CFBundleTypeIconFiles</key>
 			<array/>
 			<key>CFBundleTypeName</key>
-			<string>Clojure</string>
+			<string>ClojureScript</string>
 			<key>CFBundleTypeRole</key>
 			<string>Editor</string>
 			<key>LSHandlerRank</key>
 			<string>Owner</string>
 			<key>LSItemContentTypes</key>
 			<array>
-				<string>public.data</string>
+				<string>public.source-code</string>
 			</array>
 		</dict>
 	</array>
@@ -68,6 +68,42 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+	</array>
+	<key>UTExportedTypeDeclarations</key>
+	<array>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.source-code</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>ClojureScript Source Code</string>
+			<key>UTTypeIdentifier</key>
+			<string>org.clojure.cljs</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.source-code</key>
+				<string>cljs</string>
+			</dict>
+		</dict>
+	</array>
+	<key>UTImportedTypeDeclarations</key>
+	<array>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.source-code</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>ClojureScript Source Code</string>
+			<key>UTTypeIdentifier</key>
+			<string>org.clojure.cljs</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.source-code</key>
+				<string>cljs</string>
+			</dict>
+		</dict>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
This is a response to the reported bug:

https://twitter.com/esten/status/791389213870661633

as noted in issue: https://github.com/mfikes/replete/issues/96

I've added both "Exported UTIs" & "Imported UTIs".

As per http://stackoverflow.com/a/7489137/1363227

* Exported UTIs are the UTIs for which your application is
authoritative. That is, document types which you own and define.

* Imported UTIs are document types which you know about but for which
some other application may be authoritative.

Should we leave both, as I don't know of any other application that is
authoritative for ClojureScript on iOS?