### PR TITLE
Massaging build scripts

### DIFF
--- a/ClojureScript/replete/script/build
+++ b/ClojureScript/replete/script/build
@@ -1,4 +1,33 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+# Make sure we fail and exit on the command that actually failed.
+set -e
+set -o pipefail
+
+FAST_PLANCK=''
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --fast)
+      export FAST_PLANCK="--fast"
+      export FAST_BUILD=1
+      shift
+      ;;
+  esac
+done
+
+cd ../../../
+if [ ! -e planck ]; then
+  curl -L https://github.com/planck-repl/planck/archive/master.tar.gz | gunzip | tar x
+  ln -s planck-master planck
+fi
+cd -
+
+cd ../../../planck
+if [ ! -e planck-c/build/planck ]; then
+  osascript -e 'display notification "Building planck..." with title "Replete"'
+  script/build $FAST_PLANCK
+fi
+cd -
 
 mkdir -p aot-cache
 lein deps
@@ -13,10 +42,8 @@ echo "AOT compiling macros"
   'cljs.core.async.impl.ioc-macros)
 REPL_INPUT
 
-mkdir -p out/clojure
 mkdir -p out/clojure/test/check
 mkdir -p out/cljs/analyzer
-mkdir -p out/cljs/spec
 mkdir -p out/cljs/spec/test
 mkdir -p out/cljs/spec/gen
 mkdir -p out/cljs/core/async/impl
@@ -33,15 +60,16 @@ cp ../../../planck/planck-cljs/out/cljs/spec/gen/alpha\$macros.js out/cljs/spec/
 cp ../../../planck/planck-cljs/out/cljs/test\$macros.cache.json out/cljs/test\$macros.cljc.cache.json
 cp ../../../planck/planck-cljs/out/cljs/test\$macros.js out/cljs/test\$macros.js
 
+# Note: --fast will cause some of these files to be missing.  These have been marked optional via '|| true'.
 cp aot-cache/clojure_SLASH_test_SLASH_check_SLASH_clojure_test\$macros.cache.json out/clojure/test/check/clojure_test\$macros.cljc.cache.json
 cp aot-cache/clojure_SLASH_test_SLASH_check_SLASH_clojure_test\$macros.js out/clojure/test/check/clojure_test\$macros.js
-cp aot-cache/clojure_SLASH_test_SLASH_check_SLASH_clojure_test\$macros.js.map.json out/clojure/test/check/clojure_test\$macros.cljc.map.json
+cp aot-cache/clojure_SLASH_test_SLASH_check_SLASH_clojure_test\$macros.js.map.json out/clojure/test/check/clojure_test\$macros.cljc.map.json || true
 cp aot-cache/clojure_SLASH_test_SLASH_check_SLASH_properties\$macros.cache.json out/clojure/test/check/properties\$macros.cljc.cache.json
 cp aot-cache/clojure_SLASH_test_SLASH_check_SLASH_properties\$macros.js out/clojure/test/check/properties\$macros.js
 cp aot-cache/clojure_SLASH_test_SLASH_check_SLASH_properties\$macros.js.map.json out/clojure/test/check/properties\$macros.cljc.map.json
 cp aot-cache/cljs_SLASH_core_SLASH_async_SLASH_impl_SLASH_ioc_macros\$macros.cache.json out/cljs/core/async/impl/ioc_macros\$macros.clj.cache.json
 cp aot-cache/cljs_SLASH_core_SLASH_async_SLASH_impl_SLASH_ioc_macros\$macros.js out/cljs/core/async/impl/ioc_macros\$macros.js
-cp aot-cache/cljs_SLASH_core_SLASH_async_SLASH_impl_SLASH_ioc_macros\$macros.js.map.json out/cljs/core/async/impl/ioc_macros\$macros.clj.map.json
+cp aot-cache/cljs_SLASH_core_SLASH_async_SLASH_impl_SLASH_ioc_macros\$macros.js.map.json out/cljs/core/async/impl/ioc_macros\$macros.clj.map.json || true
 cp aot-cache/cljs_SLASH_core_SLASH_async_SLASH_macros\$macros.cache.json out/cljs/core/async/macros\$macros.cljc.cache.json
 cp aot-cache/cljs_SLASH_core_SLASH_async_SLASH_macros\$macros.js out/cljs/core/async/macros\$macros.js
 cp aot-cache/cljs_SLASH_core_SLASH_async_SLASH_macros\$macros.js.map.json out/cljs/core/async/macros\$macros.cljc.map.json
@@ -50,6 +78,7 @@ cp aot-cache/cljs_SLASH_core_SLASH_async\$macros.js out/cljs/core/async\$macros.
 cp aot-cache/cljs_SLASH_core_SLASH_async\$macros.js.map.json out/cljs/core/async\$macros.cljc.map.json
 
 echo "Compiling ClojureScript"
+osascript -e 'display notification "Compiling ClojureScript..." with title "Replete"'
 lein run -m clojure.main script/build.clj
 
 script/bundle

--- a/ClojureScript/replete/script/bundle
+++ b/ClojureScript/replete/script/bundle
@@ -25,6 +25,12 @@ EOF
 
 CLOSURE_OPTIMIZATIONS="${CLOSURE_OPTIMIZATIONS:-SIMPLE}"
 
+if [ $FAST_BUILD == "1" ]
+then
+  echo "Because this is a fast build, setting Closure Optimizations to NONE"
+  CLOSURE_OPTIMIZATIONS=NONE
+fi
+
 if [ $CLOSURE_OPTIMIZATIONS != "NONE" ]
 then
   echo "### Optimizing bundled JavaScript with Closure Optimizations:" $CLOSURE_OPTIMIZATIONS
@@ -42,6 +48,7 @@ if [ $CLOSURE_OPTIMIZATIONS != "NONE" ] && [ ${file: -3} == ".js" ] && [ "${file
 then
   if [ ! -f $file.optim ] || [ $file -nt $file.optim ]
   then
+    osascript -e 'display notification "Closure compiling $file" with title "Replete"'
     java -jar ../compiler/closure-compiler-v$CLOSURE_RELEASE.jar --compilation_level $CLOSURE_OPTIMIZATIONS --language_in ECMASCRIPT3 --language_out ECMASCRIPT3 --process_closure_primitives false --js $file --js_output_file $file.optim
     echo -n "."
   fi
@@ -66,6 +73,7 @@ cat <<EOF >> ../bundle_dict.c
 	}
 EOF
 done
+
 if [ $CLOSURE_OPTIMIZATIONS != "NONE" ]
 then
   echo


### PR DESCRIPTION
Hey @mfikes,

Thanks so much for making Replete an open-source project 😎👍.

This PR:
- Implements a `--fast` option similar to that used by `planck`.
- Automatically fetches and builds `planck` if it isn't found.

This is just a first stab at doing this -- totally open to feedback or suggestions, e.g.:
- I could see maybe pulling out the planck fetch-and-build as its own script, similar to `get-closure-compiler`.
- Perhaps `FAST_PLANCK` could also be done away with? (e.g. have planck's `build` pull in `FAST_BUILD` from the environment?)
